### PR TITLE
Fix path separator issue in migration detection

### DIFF
--- a/SqlServer.Schema.Migration.Generator/GitIntegration/GitDiffAnalyzer.cs
+++ b/SqlServer.Schema.Migration.Generator/GitIntegration/GitDiffAnalyzer.cs
@@ -36,6 +36,9 @@ generated_script.sql
         var statusOutput = RunGitCommand(path, "status --porcelain -u");
         var lines = statusOutput.Split('\n', StringSplitOptions.RemoveEmptyEntries);
         
+        // Normalize databaseName to use forward slashes for comparison
+        var normalizedDatabaseName = databaseName.Replace('\\', '/');
+        
         foreach (var line in lines)
         {
             if (line.Length < 3) continue;
@@ -44,7 +47,7 @@ generated_script.sql
             var filePath = line.Substring(3).Trim();
             
             // Only process SQL files from the database directory
-            if (filePath.StartsWith(databaseName) && filePath.EndsWith(".sql"))
+            if (filePath.StartsWith(normalizedDatabaseName) && filePath.EndsWith(".sql"))
             {
                 var changeType = MapGitStatus(status);
                 if (changeType != ChangeType.Unknown)


### PR DESCRIPTION
## Summary
- Fixed cross-platform path separator issue preventing migration detection
- Git returns paths with forward slashes, but code was using Windows backslashes
- Added path normalization to ensure correct comparison

## Problem
The migration generator was failing to detect changes in the `pharm-n1.pharm.local` server directory because:
- Git status returns paths like `servers/pharm-n1.pharm.local/abc/...`
- The code was comparing with `servers\pharm-n1.pharm.local\abc`
- The `StartsWith` check was failing due to mismatched separators

## Solution
Normalized the database path to use forward slashes before comparison in `GitDiffAnalyzer.GetUncommittedChanges`.

## Test plan
- [x] Created test script to verify the fix
- [x] Confirmed original comparison fails and normalized comparison succeeds
- [ ] Run the migration generator to verify it now detects changes

*Collaboration by Claude*