### PR TITLE
fix: resolve duplicate variable name compilation error

### DIFF
--- a/SqlServer.Schema.Migration.Generator/GitIntegration/GitDiffAnalyzer.cs
+++ b/SqlServer.Schema.Migration.Generator/GitIntegration/GitDiffAnalyzer.cs
@@ -108,8 +108,8 @@ generated_script.sql
                     
                     // Log the commit we're on after reset
                     var commitAfterReset = RunGitCommand(path, "rev-parse HEAD").Trim();
-                    var commitMessage = RunGitCommand(path, "log -1 --pretty=%s").Trim();
-                    Console.WriteLine($"Now at commit: {commitAfterReset.Substring(0, Math.Min(8, commitAfterReset.Length))} - {commitMessage}");
+                    var commitMsgAfterReset = RunGitCommand(path, "log -1 --pretty=%s").Trim();
+                    Console.WriteLine($"Now at commit: {commitAfterReset.Substring(0, Math.Min(8, commitAfterReset.Length))} - {commitMsgAfterReset}");
                 }
                 catch (Exception resetEx)
                 {


### PR DESCRIPTION
## Summary
Quick fix for a compilation error that was preventing the project from building.

## Issue
The build was failing with:
```
error CS0136: A local or parameter named 'commitMessage' cannot be declared in this scope because that name is used in an enclosing local scope
```

## Solution
Renamed the second `commitMessage` variable to `commitMsgAfterReset` to avoid the naming conflict.

## Changes
- Changed variable name in `GitDiffAnalyzer.cs` line 111 from `commitMessage` to `commitMsgAfterReset`

## Test
- [x] Project builds successfully
- [x] No compilation errors
- [x] Functionality remains unchanged

*Collaboration by Claude*