### PR TITLE
feat: add optional commit message parameter to Dacpac.Runner

### DIFF
--- a/SqlServer.Schema.FileSystem.Serializer.Dacpac.Runner/SqlServer.Schema.FileSystem.Serializer.Dacpac.Runner.csproj
+++ b/SqlServer.Schema.FileSystem.Serializer.Dacpac.Runner/SqlServer.Schema.FileSystem.Serializer.Dacpac.Runner.csproj
@@ -22,6 +22,7 @@
   <ItemGroup>
     <PackageReference Include="Microsoft.SqlServer.DacFx" Version="*" />
     <PackageReference Include="Microsoft.Data.SqlClient" Version="*" />
+    <PackageReference Include="System.CommandLine" Version="2.0.0-beta4.22272.1" />
   </ItemGroup>
 
 </Project>


### PR DESCRIPTION
## Summary
- Added optional `--commit-message` parameter to SqlServer.Schema.FileSystem.Serializer.Dacpac.Runner
- Allows users to specify custom git commit messages when database structure is generated
- Maintains backward compatibility with legacy positional arguments

## Changes
- Added System.CommandLine NuGet package for robust CLI argument parsing
- Refactored Program.cs to use named options (--source-connection, --target-connection, --output-path, --commit-message)
- Implemented git commit functionality after successful database structure generation
- Commits only happen when there are actual changes to commit
- Default commit message: "Update database structure for {server}/{database}"

## Usage
```bash
# Using named options with custom commit message
dotnet run -- --source-connection "..." --target-connection "..." --output-path "/path" --commit-message "Custom message"

# Using short aliases
dotnet run -- -s "..." -t "..." -o "/path" -m "Custom message"

# Legacy positional arguments (for backward compatibility)
dotnet run -- "source_conn" "target_conn" "/path" "Custom message"
```

## Test plan
- [x] Build succeeds
- [x] Help output displays correctly
- [x] Legacy positional arguments still work
- [ ] Test with actual database connections
- [ ] Verify commit message is used when provided
- [ ] Verify default commit message when not provided

*Collaboration by Claude*