### PR TITLE
fix: fetch only from origin main instead of all remotes

### DIFF
--- a/SqlServer.Schema.Migration.Generator/GitIntegration/GitDiffAnalyzer.cs
+++ b/SqlServer.Schema.Migration.Generator/GitIntegration/GitDiffAnalyzer.cs
@@ -343,8 +343,8 @@ generated_script.sql
             {
                 try
                 {
-                    Console.WriteLine("\nFetching latest changes from all remotes...");
-                    var fetchOutput = RunGitCommand(path, "fetch --all --verbose");
+                    Console.WriteLine("Fetching latest changes from origin main...");
+                    var fetchOutput = RunGitCommand(path, "fetch origin main --verbose");
                     Console.WriteLine("✓ Fetch completed successfully");
                     if (!string.IsNullOrWhiteSpace(fetchOutput))
                     {


### PR DESCRIPTION
## Summary
- Changed fetch operation to target only origin main branch instead of fetching from all remotes
- More efficient and focused fetch operation
- Reduces unnecessary network traffic

## Changes Made
- Updated `GitDiffAnalyzer.cs` to use `fetch origin main --verbose` instead of `fetch --all --verbose`
- Updated console message to reflect the more specific fetch operation

## Test Plan
- [x] Verify that fetch operation works correctly with origin main
- [x] Ensure migration generation still functions properly
- [x] Check that CI/CD workflows continue to work as expected

*Collaboration by Claude*