### PR TITLE
Fix Dockerfile project references

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -10,13 +10,14 @@ COPY *.sln ./
 COPY Directory.Build.props ./
 COPY VERSION ./
 
-# Copy project files
+# Copy all project files for restore
 COPY SqlServer.Schema.FileSystem.Serializer.Dacpac.Runner/*.csproj ./SqlServer.Schema.FileSystem.Serializer.Dacpac.Runner/
 COPY SqlServer.Schema.FileSystem.Serializer.Dacpac.Core/*.csproj ./SqlServer.Schema.FileSystem.Serializer.Dacpac.Core/
 COPY SqlServer.Schema.Migration.Generator/*.csproj ./SqlServer.Schema.Migration.Generator/
+COPY SqlServer.Schema.Migration.Runner/*.csproj ./SqlServer.Schema.Migration.Runner/
+COPY SqlServer.Schema.Migration.Generator.Tests/*.csproj ./SqlServer.Schema.Migration.Generator.Tests/
 COPY SqlServer.Schema.Exclusion.Manager/*.csproj ./SqlServer.Schema.Exclusion.Manager/
-COPY SqlServer.Dac.Core/*.csproj ./SqlServer.Dac.Core/
-COPY SqlServer.Dac.Extensions/*.csproj ./SqlServer.Dac.Extensions/
+COPY SqlServer.Schema.Exclusion.Manager.Tests/*.csproj ./SqlServer.Schema.Exclusion.Manager.Tests/
 
 # Restore dependencies
 RUN dotnet restore


### PR DESCRIPTION
## Summary
- Fixed Dockerfile to include all required project files for successful build
- Removed references to non-existent projects that were causing build failures

## Changes
- Removed SqlServer.Dac.Core and SqlServer.Dac.Extensions (don't exist)
- Added all project files including test projects and Migration.Runner
- Ensures dotnet restore can resolve all solution dependencies

## Test Status
✅ Docker build tested locally and completes successfully
✅ Both DACPAC Runner and Exclusion Manager publish correctly

*Collaboration by Claude*